### PR TITLE
Added two new version of youtubes thumbnail images (maxres and standard)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var config = {
 		default: 'default',
 		high:    'hqdefault',
 		medium:  'mqdefault',
+		standard: 'sddefault',
+		maxres:  'maxresdefault'
 	}
 }; 
 


### PR DESCRIPTION
Saw this two version missing and maxres is the one you often want since it is the one with the highest resolution. 
